### PR TITLE
Generics and TypeScript limited to 4.6.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.2.7](https://github.com/wessberg/di-compiler/compare/v2.2.6...v2.2.7) (2022-5-26)
+
+### Bug fixes
+
+* Fixed issue with generics to allow `container.register<IService<Generic>, Service<Generic>>()`.
+* Restricted `typescript` to minor version updates from `~4.6.4` as version 4.7 is currently incompatible.
+
 ## [2.2.6](https://github.com/wessberg/di-compiler/compare/v2.2.5...v2.2.6) (2021-11-19)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wessberg/di-compiler",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "A Custom Transformer for Typescript that enables compile-time Dependency Injection",
   "scripts": {
     "generate:sandhog": "sandhog all --yes",
@@ -76,7 +76,7 @@
     "crosspath": "^1.0.0",
     "ts-node": "^10.8.0",
     "npm-check-updates": "^13.0.3",
-    "typescript": "^4.6.4",
+    "typescript": "~4.6.4",
     "typescript-3-4-1": "npm:typescript@3.4.1",
     "typescript-3-5-1": "npm:typescript@3.5.1",
     "typescript-3-6-2": "npm:typescript@3.6.2",

--- a/src/transformer/before/visitor/visit-call-expression.ts
+++ b/src/transformer/before/visitor/visit-call-expression.ts
@@ -44,7 +44,7 @@ export function visitCallExpression(
               factory.createPropertyAssignment(
                 "identifier",
                 factory.createStringLiteral(
-                  node.typeArguments[0].getFullText().trim()
+                  node.typeArguments[0].getFirstToken()!.getFullText().trim()
                 )
               ),
             ]),


### PR DESCRIPTION
This pull addresses two things:
1) Support for generics, as per #11.  
2) Limits TypeScript in `package.json` to `~4.6.4`, as recently released 4.7 does not currently work.  Obviously back out this change when 4.7 is supported.

Passes all tests, and change #1 has been in my rig for a couple months now.

I did bump the version number and add a change log.  Sorry if this was inappropriate - some smaller projects like it when I assist with the details, others find it a major faux pas!  In the change log I refer to the labeled version, which of course does not exist yet.  Glad to fix the repo to remove that if you prefer.