### PR TITLE
JSX support for transform() API method

### DIFF
--- a/src/transformer/transform.ts
+++ b/src/transformer/transform.ts
@@ -40,7 +40,7 @@ export function transform(source: string, filenameOrOptions: string | TransformO
 	const transformationContext = typescript.nullTransformationContext;
 	const visitorContext = {...baseVisitorContext, transformationContext, factory};
 
-	const sourceFile = typescript.createSourceFile(filename, source, typescript.ScriptTarget.ESNext, true, typescript.ScriptKind.TS);
+	const sourceFile = typescript.createSourceFile(filename, source, typescript.ScriptTarget.ESNext, true);
 	const transformedSourceFile = transformSourceFile(sourceFile, visitorContext);
 
 	let result: TransformResult;

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -128,3 +128,43 @@ test("The transform API goes from TypeScript to TypeScript. #4", "*", (t, {types
 
 	t.true(map != null);
 });
+
+test("The transform API allows JSX code. #1", "*", (t, {typescript}) => {
+	const {code } = generateTransformResult({
+		fileName: "file.tsx",
+		text: `import {IFoo} from "./foo";
+		
+		const foo = container.get<IFoo>();
+
+		return <div id="wrapper">{foo.name}</div>;`},
+		{
+			typescript,
+			identifier: 'container'
+		}
+	);
+
+	t.deepEqual(
+		formatCode(code),
+		formatCode(`\
+		import { IFoo } from "./foo";
+		const foo = container.get<IFoo>({ identifier: "IFoo" });
+		return <div id="wrapper">{foo.name}</div>;`)
+	);
+});
+
+test("The transform API allows JSX code. #2", "*", (t, {typescript}) => {
+	const {code} =  generateTransformResult({
+			fileName: "file.ts",
+			text: `import {IFoo} from "./foo";
+
+		const foo = container.get<IFoo>();
+
+		return <div id="wrapper">{foo.name}</div>;`},
+		{
+			typescript,
+			identifier: 'container'
+		}
+	);
+
+	t.throws(() => formatCode(code));
+});


### PR DESCRIPTION
This change enables JSX support for `transform()` method as described in #24. Tests were added, I hope they meet the guidelines.