### PR TITLE
Support for classes that extend DIContainer with new option

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,11 +272,12 @@ be extremely fast.
 
 You can pass in a few options to DI-Compiler via command line options:
 
-| Environment Variable        | Description                                                                                                                 |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `DI_COMPILER_TSCONFIG_PATH` | The path to the `tsconfig.json` file to use                                                                                 |
-| `DI_COMPILER_IDENTIFIER`    | A comma-separated list of identifiers that should be considered instances of DIContainer when transforming the source files |
-| `DI_COMPILER_DISABLE_CACHE` | If set, no disk caching will be used.                                                                                       |
+| Environment Variable        | Description                                                                                                                   |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `DI_COMPILER_TSCONFIG_PATH` | The path to the `tsconfig.json` file to use                                                                                   |
+| `DI_COMPILER_IDENTIFIER`    | A comma-separated list of identifiers that should be considered instances of `DIContainer` when transforming the source files |
+| `DI_COMPILER_CLASS_NAME`    | A comma-separated list of additional class names for `DIContainer`, for custom extensions that inherit the class.             |
+| `DI_COMPILER_DISABLE_CACHE` | If set, no disk caching will be used.                                                                                         |
 
 Alternatively, you can add a `di` property to your `tsconfig` where you can customize its behavior without setting environment variables:
 
@@ -285,6 +286,7 @@ Alternatively, you can add a `di` property to your `tsconfig` where you can cust
 {
 	"di": {
 		"identifier": "container",
+		"diClassName": ["CustomDIContainer", "AnotherDIContainer"],
 		"disableCache": false
 	},
 	"compilerOptions": {

--- a/src/transformer/before/visitor/visit-call-expression.ts
+++ b/src/transformer/before/visitor/visit-call-expression.ts
@@ -1,4 +1,3 @@
-import {DI_CONTAINER_NAME} from "../../constant.js";
 import type {TS} from "../../../type/type.js";
 import type {BeforeVisitorOptions} from "../before-visitor-options.js";
 import type {DiMethodName} from "../../di-method-kind.js";
@@ -6,6 +5,7 @@ import type {VisitorContext} from "../../visitor-context.js";
 import {getImportDefaultHelper, getImportStarHelper, moduleKindDefinesDependencies, moduleKindSupportsImportHelpers} from "../../../util/ts-util.js";
 import {pickServiceOrImplementationName} from "../util.js";
 import {ensureArray} from "../../../util/util.js";
+import { isDiClassName } from '../../../loader/shared.js';
 
 export function visitCallExpression(options: BeforeVisitorOptions<TS.CallExpression>): TS.VisitResult<TS.Node> {
 	const {node, childContinuation, continuation, context, addTslibDefinition, requireImportedSymbol} = options;
@@ -283,7 +283,7 @@ function isDiContainerInstance(node: TS.PropertyAccessExpression | TS.ElementAcc
 		// Don't proceed unless the left-hand expression is the DIServiceContainer
 		const type = context.typeChecker.getTypeAtLocation(node.expression);
 
-		if (type == null || type.symbol == null || type.symbol.escapedName !== DI_CONTAINER_NAME) {
+		if (type == null || type.symbol == null || !isDiClassName(type.symbol.escapedName)) {
 			return false;
 		}
 	} else {
@@ -303,7 +303,7 @@ function isDiContainerInstance(node: TS.PropertyAccessExpression | TS.ElementAcc
 				!evaluationResult.success ||
 				evaluationResult.value == null ||
 				typeof evaluationResult.value !== "object" ||
-				evaluationResult.value.constructor?.name !== DI_CONTAINER_NAME
+				!isDiClassName(evaluationResult.value.constructor?.name)
 			) {
 				return false;
 			}

--- a/src/transformer/di-options.ts
+++ b/src/transformer/di-options.ts
@@ -15,6 +15,11 @@ export interface DiIsolatedModulesOptions extends DiOptionsBase {
 	 * Providing one or more identifiers up front can be considered an optimization, as this step can be skipped that way
 	 */
 	identifier?: MaybeArray<string>;
+	/*
+	 * Additional class name(s) that should be considered as the implementation class DIContainer. Required when inheriting
+	 * from DIContainer to add functionality to have the transofmrer recognize the class as a DIContainer.
+	 */
+	diClassName?: MaybeArray<string>;
 	compilerOptions?: TS.CompilerOptions;
 }
 

--- a/src/transformer/di-options.ts
+++ b/src/transformer/di-options.ts
@@ -5,7 +5,7 @@ interface DiOptionsBase {
 }
 
 export interface DiProgramOptions extends DiOptionsBase {
-	program: TS.Program;
+	program: TS.Program & DiIsolatedModulesOptions;
 }
 
 export interface DiIsolatedModulesOptions extends DiOptionsBase {

--- a/src/transformer/di.ts
+++ b/src/transformer/di.ts
@@ -1,13 +1,24 @@
-import type {TS} from "../type/type.js";
-import type {DiOptions} from "./di-options.js";
+import {TS} from "../type/type.js";
+import type {DiIsolatedModulesOptions, DiOptions} from "./di-options.js";
 import {beforeTransformer} from "./before/before-transformer.js";
 import {afterTransformer} from "./after/after-transformer.js";
 import {getBaseVisitorContext} from "./get-base-visitor-context.js";
+import { resolveOptions } from '../loader/shared.js';
 
 /**
  * CustomTransformer that associates constructor arguments with any given class declaration
  */
 export function di(options: DiOptions): TS.CustomTransformers {
+	const transformOptions = <DiIsolatedModulesOptions> resolveOptions(options.typescript ?? TS);
+	
+	if ("program" in options) {
+		options.program.identifier = transformOptions.identifier;
+		options.program.diClassName = transformOptions.diClassName;
+	} else {
+		options.identifier = transformOptions.identifier;
+		options.diClassName = transformOptions.diClassName;
+	}
+
 	const baseVisitorContext = getBaseVisitorContext(options);
 
 	return {

--- a/src/transformer/get-base-visitor-context.ts
+++ b/src/transformer/get-base-visitor-context.ts
@@ -45,7 +45,8 @@ export function getBaseVisitorContext({typescript = TSModule as typeof TS, ...re
 	} else {
 		const compilerOptions = rest.compilerOptions ?? typescript.getDefaultCompilerOptions();
 		return {
-			identifier: [],
+			identifier: rest.identifier ?? [],
+			diClassName: rest.diClassName ?? [],
 
 			...rest,
 			...visitorContextShared,


### PR DESCRIPTION
New feature:
- **Support implementations that extend `DIContainer`**: Adds a new environment variable `DI_COMPILER_CLASS_NAME` (and associated `di.diClassName` option) to specify one or more names of classes that inherit from `DIContainer`.  This allows one to extend DI with custom functionality without needing to request changes to the repo (and allowed me to rip out some likely wanted junk from a prior pull request and implement it in my own class).

Bugs fixed:
- **Options with transformers**: Unlike loaders, transformers use the `di()` call which did not allow any of the environment variable / di.xxx options to be used.  This adds functionality to the `di()` call to get and apply options from `resolveOptions`.

- **Adust `DIProgramOptions` type to be consistent with use**: The `DiProgramOptions` interface specified `program: TS.Program`, which is lacking the extensions added for options.  Adjusted to match implementation by changing to `program: TS.Program & DiIsolatedModulesOptions`.

- **Retain `identifier` options**: The `identifier` option was being dropped in the `getBaseVistorContext` function with `identifer: []`.  Retained the options by changing to `identifier: rest.identifier ?? []`.

This passes all test cases, but no new test cases added as I didn't see any test code that tested options.