### PR TITLE
Support custom tsconfig paths

### DIFF
--- a/src/loader/shared.ts
+++ b/src/loader/shared.ts
@@ -27,6 +27,10 @@ interface ExtendedTsconfig {
 }
 
 export function resolveOptions(typescript: typeof TS): Partial<TransformOptions> {
+	// check if a custom path is in use for the tsconfig.json file
+	const tsconfigFlagIndex = typescript.sys.args.findIndex(arg => arg === "-p" || arg === "--project");
+	const tsconfigFile = tsconfigFlagIndex !== -1 ? typescript.sys.args[tsconfigFlagIndex + 1] : undefined;
+
 	const tsconfig = upgradeTsconfig(
 		typescript,
 		process.env[ENV_VARIABLE_TSCONFIG_PATH] != null
@@ -34,7 +38,7 @@ export function resolveOptions(typescript: typeof TS): Partial<TransformOptions>
 					path: process.env[ENV_VARIABLE_TSCONFIG_PATH],
 					config: parseTsconfig(process.env[ENV_VARIABLE_TSCONFIG_PATH])
 			  }
-			: getTsconfig() ?? undefined
+			: getTsconfig(tsconfigFile) ?? undefined
 	);
 
 	let identifier =


### PR DESCRIPTION
Custom `tsconfig.json` file are ignored by `di-compiler`, as it uses the `get-tsconfig` package to scan for the default `tsconfig.json` file.  For example, if using `tsconfig.test.json` with `"di": { "identifier": "myContainer" }`, it will not work because `di-compiler` will load these settings from `tsconfig.json` (and not `tsconfig.test.json`).

To resolve this, the arguments passed to the compiler (in `typescript.sys.args`) are checked for the `-p` (or `--project`) options and the following parameter is used as the typescript filename, which is then provided to the `get-tsconfig` method `getTsconfig`.  If the `-p` option is not found, it results in undefined, which falls back on the existing defaults to scan for a `tsconfig.json` file.

Ran test suite and all tests pass.  Likely the github actions execution will fail again, as my last pull request failed due to a `pnpm` version compatibility issue with the actions (and #28 likely needs to be addressed as well).